### PR TITLE
document json schema endpoint in README and index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,27 @@ to get the logs messages of the `web` service of the docker-compose.yml file
 
 Run `sudo docker-compose down` to shut the services down.
 
-### API calls
+## API calls
+
+### GET `/schema/{queue}/{variant}`
+
+This endpoint returns a predefined JSON schema for a specific queue variant. The schemas are stored as Python files in the `static/` directory.
+
+#### Path parameters:
+
+- `queue`: one of `supply` or `grid`
+- `variant`: one of `input` or `output`
+
+The server looks for a file named `{queue}_schema.py` and loads a variable named `{queue}_schema_{variant}` from it.
+
+#### Error cases:
+- **404**: If the file or the corresponding variable does not exist  
+- **500**: If an error occurs while loading the file
+
+#### Use case:
+Useful for validating incoming and outgoing JSON files.
+
+### API Request and Response Formats for `/sendjson` and `/check`
 The json file for the POST request `/sendjson/supply` is structured as follow
 ```
 supply_opt_json = {

--- a/fastapi_app/templates/index.html
+++ b/fastapi_app/templates/index.html
@@ -41,6 +41,20 @@
     </form>
 </div>
 
+<div style="margin-top: 2rem; font-size: 0.9rem;">
+  <h3>Validation Schemas</h3>
+    <h4>Access:</h4>
+  <p>JSON Schemas can be accessed via <code>/schema/{queue}/{variant}</code> </p>
+  <p><strong>queue</strong> = <code>grid</code> or <code>supply</code> | <strong>variant</strong> = <code>input</code> or <code>output</code></p>
+  <h4>Available Schemas:</h4>
+    <ul style="list-style-type: none; padding-left: 0;">
+    <li><a href="/schema/supply/input">Supply Schema Input</a></li>
+    <li><a href="/schema/supply/output">Supply Schema Output</a></li>
+    <li><a href="/schema/grid/input">Grid Schema Input</a></li>
+    <li><a href="/schema/grid/output">Grid Schema Output</a></li>
+  </ul>
+</div>
+
 
 <div>
     <h2>More information</h2>


### PR DESCRIPTION
I've added documentation for accessing validation schemas in README and index.html. Does this fit what you imagined? If not, I can fix it quickly today. Closes #5 