### PR TITLE
Allow null values in grid_input columns

### DIFF
--- a/fastapi_app/static/grid_schema.py
+++ b/fastapi_app/static/grid_schema.py
@@ -43,7 +43,7 @@ grid_schema_input = {
                 },
                 "shs_options": {
                     "type": "array",
-                    "items": {"type": "number"},
+                    "items": {"type": ["integer", "null"]},
                 },
                 "consumer_detail": {
                     "type": "array",
@@ -55,11 +55,11 @@ grid_schema_input = {
                 },
                 "distance_to_load_center": {
                     "type": "array",
-                    "items": {"type": "number"},
+                    "items": {"type": ["number", "null"]},
                 },
                 "distribution_cost": {
                     "type": "array",
-                    "items": {"type": "number"},
+                    "items": {"type": ["number", "null"]},
                 },
                 "parent": {
                     "type": "array",


### PR DESCRIPTION
Can happen when a simulation has already ran and the dataframe contains pole rows.