### PR TITLE
Define utm zone only once on startup

### DIFF
--- a/task_queue/grid_optimizer.py
+++ b/task_queue/grid_optimizer.py
@@ -108,6 +108,11 @@ class GridOptimizer:
         self.start_execution_time = time.monotonic()
         self.grid_opt_json = grid_opt_json
         self.nodes = pd.DataFrame(self.grid_opt_json["nodes"])
+        utm_zone = utm.from_latlon(
+            latitude=self.nodes.latitude.mean(),
+            longitude=self.nodes.longitude.mean(),
+        )
+        self._utm_zone = utm_zone[2]
         self.grid_design_dict = self.grid_opt_json["grid_design"]
         self.yearly_demand = self.grid_opt_json["yearly_demand"]
         self.nodes_df, self.power_house = self._query_nodes()
@@ -742,9 +747,7 @@ class GridOptimizer:
             + false: lon,lat --> x,y
             + true: x,y --> lon/lat
         """
-        # extract the UTM zone from the coordinates
-        utm_zone = utm.from_latlon(latitude=self.nodes.latitude.mean(), longitude=self.nodes.longitude.mean())
-        p = Proj(proj="utm", zone=utm_zone[2], ellps="WGS84", preserve_units=False)
+        p = Proj(proj="utm", zone=self._utm_zone, ellps="WGS84", preserve_units=False)
 
         # if inverse=true, this is the case when the (x,y) coordinates of the obtained
         # poles (from the optimization) are converted into (lon,lat)

--- a/task_queue/requirements.txt
+++ b/task_queue/requirements.txt
@@ -2,6 +2,7 @@ celery
 flower
 redis
 python-multipart
+pandas==2.3.3
 oemof.network==0.5.0a1
 oemof.solph==0.5
 k-means-constrained


### PR DESCRIPTION
After k-means, the generated poles are created with:
```
poles["latitude"] = 0
poles["longitude"] = 0
```
Then convert_lonlat_xy(inverse=True) runs while those zero-valued pole coordinates are still in self.nodes, dragging the coordinates and defining the wrong zone, which in turn skews the output coordinates. 